### PR TITLE
Update esformatter and look for `.esformatter`

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "grunt": "~0.4.0"
   },
   "peerDependencies": {
-    "grunt": "~0.4.0"
+    "grunt": ">=0.4.0"
   },
   "keywords": [
     "gruntplugin"

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "test": "grunt test"
   },
   "dependencies": {
-    "esformatter": "0.7.3"
+    "esformatter": "0.9.3"
   },
   "devDependencies": {
     "grunt-contrib-jshint": "0.11.0",

--- a/package.json
+++ b/package.json
@@ -31,11 +31,11 @@
     "esformatter": "0.9.3"
   },
   "devDependencies": {
-    "grunt-contrib-jshint": "0.11.0",
-    "grunt-contrib-nodeunit": "~0.3.3",
-    "grunt-contrib-copy": "~0.5.0",
-    "grunt-contrib-clean": "~0.5.0",
-    "grunt": "~0.4.0"
+    "grunt-contrib-jshint": "1.0.0",
+    "grunt-contrib-nodeunit": "~1.0.0",
+    "grunt-contrib-copy": "~1.0.0",
+    "grunt-contrib-clean": "~1.0.0",
+    "grunt": "~1.0.1"
   },
   "peerDependencies": {
     "grunt": ">=0.4.0"

--- a/tasks/esformatter.js
+++ b/tasks/esformatter.js
@@ -12,9 +12,16 @@ var esformatter = require('esformatter');
 module.exports = function(grunt) {
 
   grunt.registerMultiTask('esformatter', 'Format JS files', function() {
-    var options = this.options({
+    var customOptions = this.options({
       skipHashbang: false
     });
+    try {
+      var options = esformatter.rc(customOptions);
+    } catch(e) {
+      grunt.log.error('Exception while loading `.esformatter` options.');
+      grunt.log.error(e.stack);
+      return;
+    }
     this.files.forEach(function(f) {
       f.src.filter(function(filepath) {
         if (!grunt.file.exists(filepath)) {


### PR DESCRIPTION
Automatically look for `.esformatter` and overwrite base settings with custom grunt-based settings.
Updated esformatter to `v0.9.3`. Updated dev dependencies. Allow Grunt `v1.0.1` to act as the peer dependency.
